### PR TITLE
Use HTTP Referer header to determine return path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ content/images
 dump.rdb
 content/comments.jsonl
 Settings.toml
+Secrets.toml

--- a/Settings.toml.example
+++ b/Settings.toml.example
@@ -1,0 +1,24 @@
+# Where to listen to requests from. Use 0.0.0.0 to listen to requests from
+# anywhere.
+listen_ip = "127.0.0.1"
+
+# Use whatever you like above 1024 (below that is reserved for system services)
+listen_port = 3090
+
+# Where your posts, templates, images and assets (JS, CSS) live, relative to
+# the velum executable.
+content_dir = "content"
+
+# What your blog is called.
+blog_title = "Velum Blog"
+
+# How many posts to show per page on the index pages.
+page_size = 15
+
+# Maximum size of the preview on index pages.
+max_preview_length = 400
+
+# This is the domain your blog is hosted on, and is used to dynamically figure
+# out the 'return to' link on article pages. If it's set incorrectly, return
+# path will default to '/', i.e. the blog home page.
+blog_host = "localhost"

--- a/content/templates/index.html.hbs
+++ b/content/templates/index.html.hbs
@@ -22,7 +22,7 @@
     <ul class="article-list">
       {{#each articles}}
       <li class="article-list_item">
-        <h2><a href="/articles/{{this.slug}}?return_to={{../return_to}}">{{this.title}}</a></h2>
+        <h2><a href="/articles/{{this.slug}}">{{this.title}}</a></h2>
         <h3 class="timestamp">{{date_from_timestamp this.timestamp}}</h3>
         <p class="content-preview">{{this.preview}}</p>
         {{> tag_list search_tag=../search_tag}}

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use std::fs;
 use serde::{Serialize, Deserialize};
 
 const CONFIG_FILE: &str = "./Settings.toml";
+const SECRETS_FILE: &str = "./Secrets.toml";
 
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct Config {
@@ -10,31 +11,50 @@ pub struct Config {
     pub content_dir: String,
     pub page_size: usize,
     pub blog_title: String,
+    pub blog_host: String,
     pub max_preview_length: usize,
+
+    #[serde(skip)]
+    pub secrets: Secrets
+}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct Secrets {
     pub admin_password_hash: Option<String>,
 }
 
 impl Config {
     pub fn load() -> Result<Self, std::io::Error> {
         let content = fs::read_to_string(CONFIG_FILE)?;
+        let secrets = fs::read_to_string(SECRETS_FILE)?;
         let mut config: Self = toml::from_str(&content)?;
+        let secrets: Secrets = toml::from_str(&secrets)?;
         if config.content_dir.starts_with("./") {
             config.content_dir = config.content_dir
                 .strip_prefix("./")
                 .unwrap()
                 .to_string();
         }
+        config.secrets = secrets;
         Ok(config)
     }
 
     pub fn save(&self) -> Result<(), std::io::Error> {
-        let s = toml::to_string(&self)
+        let config = toml::to_string(&self)
             .map_err(|e| {
                 log::error!("Failed to serialize config: {:?}", e);
                 let ek = std::io::ErrorKind::InvalidInput;
                 std::io::Error::from(ek)
             })?;
 
-        fs::write(CONFIG_FILE, s)
+        let secrets = toml::to_string(&self.secrets)
+            .map_err(|e| {
+                log::error!("Failed to serialize secrets: {:?}", e);
+                let ek = std::io::ErrorKind::InvalidInput;
+                std::io::Error::from(ek)
+            })?;
+
+        fs::write(CONFIG_FILE, config)?;
+        fs::write(SECRETS_FILE, secrets)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn check_args(config: &mut Config) {
                 println!("Passwords do not match.");
                 std::process::exit(1);
             }
-            config.admin_password_hash = Some(
+            config.secrets.admin_password_hash = Some(
                 bcrypt::hash(pw, HASH_COST).expect("Failed to hash password")
             );
 
@@ -98,7 +98,7 @@ async fn main() {
 
     let article = warp::path!("articles" / String)
         .and(warp::get())
-        .and(warp::query::<HashMap<String, String>>())
+        .and(warp::header::optional::<String>("Referer"))
         .and(codata_filter.clone())
         .and_then(article_route);
     let create_article = warp::path!("articles")

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -58,7 +58,7 @@ pub async fn do_login_route(form_data: HashMap<String, String>, data: SharedData
 
     let password = form_data.get("password");
     let password = if password.is_none() { "" } else { password.unwrap().as_str() };
-    let hash = mdata.config.admin_password_hash.as_ref();
+    let hash = mdata.config.secrets.admin_password_hash.as_ref();
     let hash = if hash.is_none() { "" } else { hash.unwrap().as_str() };
     let verified = bcrypt::verify(&password, hash).unwrap_or(false);
 


### PR DESCRIPTION
This removes the need for `?return_to=/` query strings on article links, making their 'visited' status more consistent.

* Move admin password hash to a new Settings.toml file, which is not included in the Git repository.

* Add a new Settings.toml.example file, which explains what each setting does.