### PR TITLE
Fix referer regex to also match tags with numbers in them

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -181,7 +181,7 @@ fn return_path(blog_host: &str, uri: Option<String>) -> String {
             //   /index/<page>
             //   /tag/<tag>
             //   /tag/<tag>/<page>
-            r"^(/index/\d+)|(/tag/[a-z\-]+(/\d+)?)"
+            r"^(/index/\d+)|(/tag/[a-z0-9\-]+(/\d+)?)"
         ).unwrap();
     }
     let default_path = "/".to_string();


### PR DESCRIPTION
Previously tags like '23mm' would not match, resulting in use of default return path instead of tag-specific one.