### PR TITLE
Move filters to module

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1,0 +1,181 @@
+use std::sync::{Arc, Mutex};
+use std::path::PathBuf;
+use core::convert::TryFrom;
+use std::collections::HashMap;
+
+use warp::{Filter, Reply, http::Uri};
+
+use crate::MAX_ARTICLE_LENGTH;
+use crate::routes::{
+    index_page_route,
+    tag_search_route,
+
+    article_route,
+    article_text_route,
+    create_article_route,
+    update_article_route,
+    delete_article_route,
+
+    comment_route,
+
+    admin_route,
+    login_page_route,
+    do_login_route,
+    do_logout_route,
+    rebuild_index_route,
+
+    timestamped_asset_route,
+};
+
+pub type SharedData = Arc<Mutex<crate::CommonData>>;
+
+pub fn index_filter(codata: SharedData) -> impl Filter<
+    Extract = impl warp::Reply,
+    Error=warp::Rejection
+> + Clone + 'static {
+    let codata_filter = warp::any().map(move || codata.clone());
+    let index = warp::path::end().map(|| 1usize)
+        .and(codata_filter.clone())
+        .and_then(index_page_route);
+    let index_at_page = warp::path!("index" / usize)
+        .and(codata_filter.clone())
+        .and_then(index_page_route);
+
+    let with_tag = warp::path!("tag" / String)
+        .map(|tag: String| (tag, 1) )
+        .untuple_one()
+        .and(codata_filter.clone())
+        .and_then(tag_search_route);
+    let with_tag_at_page = warp::path!("tag" / String / usize)
+        .and(codata_filter)
+        .and_then(tag_search_route);
+
+    index.or(index_at_page).or(with_tag).or(with_tag_at_page)
+}
+
+pub fn article_filter(codata: SharedData) -> impl Filter<
+    Extract = impl warp::Reply,
+    Error=warp::Rejection
+> + Clone + 'static {
+    let codata_filter = warp::any().map(move || codata.clone());
+    let show = warp::path!("articles" / String)
+        .and(warp::get())
+        .and(warp::header::optional::<String>("Referer"))
+        .and(codata_filter.clone())
+        .and_then(article_route);
+    let create = warp::path!("articles")
+        .and(warp::post())
+        .and(warp::filters::body::bytes())
+        .and(warp::body::content_length_limit(MAX_ARTICLE_LENGTH))
+        .and(warp::cookie::optional::<String>("session_id"))
+        .and(codata_filter.clone())
+        .and_then(create_article_route);
+    let update = warp::path!("articles" / String)
+        .and(warp::put())
+        .and(warp::filters::body::bytes())
+        .and(warp::body::content_length_limit(MAX_ARTICLE_LENGTH))
+        .and(warp::cookie::optional::<String>("session_id"))
+        .and(codata_filter.clone())
+        .and_then(update_article_route);
+    let delete = warp::path!("articles" / String)
+        .and(warp::delete())
+        .and(warp::cookie::optional::<String>("session_id"))
+        .and(codata_filter.clone())
+        .and_then(delete_article_route);
+
+    let text = warp::path!("articles" / String / "text")
+        .and(codata_filter)
+        .and_then(article_text_route);
+
+    // Only necessary for handling imported articles from Ghost blog.
+    let legacy = warp::path!(String)
+        .and(warp::query::<HashMap<String, String>>())
+        .and(warp::get())
+        .map(|slug, _| {
+            let path = Uri::try_from(format!("/articles/{}", slug));
+            warp::redirect::redirect(
+                path.unwrap_or_else(|_| Uri::from_static("/"))
+            ).into_response()
+        });
+
+    show.or(create).or(update).or(delete).or(text).or(legacy)
+}
+
+pub fn comment_filter(codata: SharedData) -> impl Filter<
+    Extract = impl warp::Reply,
+    Error=warp::Rejection
+> + Clone + 'static {
+    let codata_filter = warp::any().map(move || codata.clone());
+    warp::path!("comment" / String)
+        .and(warp::post())
+        .and(warp::filters::body::form())
+        .and(warp::body::content_length_limit(4000))
+        .and(warp::filters::addr::remote())
+        .and(codata_filter)
+        .and_then(comment_route)
+}
+
+pub fn admin_filter(codata: SharedData) -> impl Filter<
+    Extract = impl warp::Reply,
+    Error=warp::Rejection
+> + Clone + 'static {
+    let codata_filter = warp::any().map(move || codata.clone());
+    let page = warp::path!("admin")
+        .and(warp::cookie::optional::<String>("session_id"))
+        .and(codata_filter.clone())
+        .and_then(admin_route);
+    let login_page = warp::path!("login")
+        .and(warp::get())
+        .and(codata_filter.clone())
+        .and_then(login_page_route);
+    let do_login = warp::path!("login")
+        .and(warp::post())
+        .and(warp::body::form())
+        .and(warp::body::content_length_limit(2048))
+        .and(codata_filter.clone())
+        .and_then(do_login_route);
+    let do_logout = warp::path!("logout")
+        .and(codata_filter.clone())
+        .and(warp::post())
+        .and(warp::body::content_length_limit(0))
+        .and_then(do_logout_route);
+    let rebuild_index = warp::path!("rebuild")
+        .and(warp::cookie::optional::<String>("session_id"))
+        .and(warp::post())
+        .and(warp::body::content_length_limit(0))
+        .and(codata_filter)
+        .and_then(rebuild_index_route);
+    page.or(login_page).or(do_login).or(do_logout).or(rebuild_index)
+}
+
+pub fn statics_filter(codata: SharedData, path: &str) -> impl Filter<
+    Extract = impl warp::Reply,
+    Error=warp::Rejection
+> + Clone + 'static {
+    let path = PathBuf::from(path);
+    let codata_filter = warp::any().map(move || codata.clone());
+    let images = warp::path("content")
+        .and(warp::path("images"))
+        .and(warp::fs::dir(path.join("images")));
+    let timestamped_asset = warp::path!("assets" / String)
+        .and(codata_filter)
+        .and_then(timestamped_asset_route);
+
+    let assets = warp::path("assets").and(warp::fs::dir(path.join("assets")));
+
+    let robots_txt = warp::path!("robots.txt").map(|| "");
+
+    let favicon16 = warp::path!("favicon16.png")
+        .and(warp::fs::file(path.join("favicon16.png")));
+    let favicon32 = warp::path!("favicon32.png")
+        .and(warp::fs::file(path.join("favicon32.png")));
+    let favicon_apple = warp::path!("favicon_apple.png")
+        .and(warp::fs::file(path.join("favicon_apple.png")));
+    images
+        .or(timestamped_asset)
+        .or(assets)
+        .or(robots_txt)
+        .or(favicon16)
+        .or(favicon32)
+        .or(favicon_apple)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,40 +4,31 @@ mod hb;
 mod comments;
 mod errors;
 mod routes;
+mod filters;
 mod config;
 mod io;
 
 use std::sync::{Arc, Mutex};
-use std::path::PathBuf;
 use std::time;
 use std::env;
 use std::net::IpAddr;
-use std::collections::HashMap;
-use core::convert::TryFrom;
-use warp::{Filter, Reply, http::Uri};
+
+use warp::Filter;
+
 use crate::config::Config;
 use commondata::CommonData;
-use routes::{
-    index_page_route,
-    tag_search_route,
-    article_route,
-    article_text_route,
-    create_article_route,
-    update_article_route,
-    delete_article_route,
-    comment_route,
-    file_not_found_route,
-    admin_route,
-    login_page_route,
-    do_login_route,
-    do_logout_route,
-    rebuild_index_route,
-    timestamped_asset_route,
+use filters::{
+    index_filter,
+    article_filter,
+    comment_filter,
+    admin_filter,
+    statics_filter,
 };
+use routes::file_not_found_route;
 
 #[macro_use] extern crate lazy_static;
 
-const MAX_ARTICLE_LENGTH: u64 = 100_000;
+pub const MAX_ARTICLE_LENGTH: u64 = 100_000;
 
 fn check_args(config: &mut Config) {
     let args: Vec<String> = env::args().collect();
@@ -59,118 +50,6 @@ async fn main() {
 
     check_args(&mut config);
 
-    let codata_filter = warp::any()
-        .map(move || shared_codata.clone());
-
-    let article_index = warp::path::end().map(|| 1usize)
-        .and(codata_filter.clone())
-        .and_then(index_page_route);
-    let article_index_at_page = warp::path!("index" / usize)
-        .and(codata_filter.clone())
-        .and_then(index_page_route);
-
-    let articles_with_tag = warp::path!("tag" / String)
-        .map(|tag: String| (tag, 1) )
-        .untuple_one()
-        .and(codata_filter.clone())
-        .and_then(tag_search_route);
-    let articles_with_tag_at_page = warp::path!("tag" / String / usize)
-        .and(codata_filter.clone())
-        .and_then(tag_search_route);
-
-    let article = warp::path!("articles" / String)
-        .and(warp::get())
-        .and(warp::header::optional::<String>("Referer"))
-        .and(codata_filter.clone())
-        .and_then(article_route);
-    let create_article = warp::path!("articles")
-        .and(warp::post())
-        .and(warp::filters::body::bytes())
-        .and(warp::body::content_length_limit(MAX_ARTICLE_LENGTH))
-        .and(warp::cookie::optional::<String>("session_id"))
-        .and(codata_filter.clone())
-        .and_then(create_article_route);
-    let update_article = warp::path!("articles" / String)
-        .and(warp::put())
-        .and(warp::filters::body::bytes())
-        .and(warp::body::content_length_limit(MAX_ARTICLE_LENGTH))
-        .and(warp::cookie::optional::<String>("session_id"))
-        .and(codata_filter.clone())
-        .and_then(update_article_route);
-    let delete_article = warp::path!("articles" / String)
-        .and(warp::delete())
-        .and(warp::cookie::optional::<String>("session_id"))
-        .and(codata_filter.clone())
-        .and_then(delete_article_route);
-
-    let article_text = warp::path!("articles" / String / "text")
-        .and(codata_filter.clone())
-        .and_then(article_text_route);
-
-    // Only necessary for handling imported articles from Ghost blog.
-    let legacy_article = warp::path!(String)
-        .and(warp::query::<HashMap<String, String>>())
-        .and(warp::get())
-        .map(|slug, _| {
-            let path = Uri::try_from(format!("/articles/{}", slug));
-            warp::redirect::redirect(
-                path.unwrap_or_else(|_| Uri::from_static("/"))
-            ).into_response()
-        });
-
-    let comment = warp::path!("comment" / String)
-        .and(warp::post())
-        .and(warp::filters::body::form())
-        .and(warp::body::content_length_limit(4000))
-        .and(warp::filters::addr::remote())
-        .and(codata_filter.clone())
-        .and_then(comment_route);
-
-    let admin = warp::path!("admin")
-        .and(warp::cookie::optional::<String>("session_id"))
-        .and(codata_filter.clone())
-        .and_then(admin_route);
-    let login_page = warp::path!("login")
-        .and(warp::get())
-        .and(codata_filter.clone())
-        .and_then(login_page_route);
-    let do_login = warp::path!("login")
-        .and(warp::post())
-        .and(warp::body::form())
-        .and(warp::body::content_length_limit(2048))
-        .and(codata_filter.clone())
-        .and_then(do_login_route);
-    let do_logout = warp::path!("logout")
-        .and(codata_filter.clone())
-        .and(warp::post())
-        .and(warp::body::content_length_limit(0))
-        .and_then(do_logout_route);
-    let rebuild_index = warp::path!("rebuild")
-        .and(warp::cookie::optional::<String>("session_id"))
-        .and(warp::post())
-        .and(warp::body::content_length_limit(0))
-        .and(codata_filter.clone())
-        .and_then(rebuild_index_route);
-
-    let path = PathBuf::from(&config.content_dir);
-    let images = warp::path("content")
-        .and(warp::path("images"))
-        .and(warp::fs::dir(path.join("images")));
-    let timestamped_asset = warp::path!("assets" / String)
-        .and(codata_filter.clone())
-        .and_then(timestamped_asset_route);
-
-    let assets = warp::path("assets").and(warp::fs::dir(path.join("assets")));
-
-    let robots_txt = warp::path!("robots.txt").map(|| "");
-
-    let favicon16 = warp::path!("favicon16.png")
-        .and(warp::fs::file(path.join("favicon16.png")));
-    let favicon32 = warp::path!("favicon32.png")
-        .and(warp::fs::file(path.join("favicon32.png")));
-    let favicon_apple = warp::path!("favicon_apple.png")
-        .and(warp::fs::file(path.join("favicon_apple.png")));
-
     let error_logger = warp::filters::log::custom(|info| {
         let s = info.status();
         let msg = format!(
@@ -190,27 +69,11 @@ async fn main() {
         }
     });
 
-    let routes = article_index
-        .or(article_index_at_page)
-        .or(article)
-        .or(create_article)
-        .or(update_article)
-        .or(delete_article)
-        .or(article_text)
-        .or(articles_with_tag)
-        .or(articles_with_tag_at_page)
-        .or(comment)
-        .or(admin)
-        .or(login_page)
-        .or(do_login)
-        .or(do_logout)
-        .or(rebuild_index)
-        .or(images)
-        .or(timestamped_asset) // needs to come before assets, as it might reject
-        .or(assets)
-        .or(robots_txt)
-        .or(favicon16).or(favicon32).or(favicon_apple)
-        .or(legacy_article)
+    let routes = index_filter(shared_codata.clone())
+        .or(article_filter(shared_codata.clone()))
+        .or(comment_filter(shared_codata.clone()))
+        .or(admin_filter(shared_codata.clone()))
+        .or(statics_filter(shared_codata.clone(), &config.content_dir))
         .recover(file_not_found_route)
         .with(error_logger);
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,5 +1,4 @@
 mod admin;
-use std::sync::{Arc, Mutex};
 use std::collections::HashMap;
 use std::{fs, time::{self, SystemTime, UNIX_EPOCH}};
 use std::io::Read;
@@ -25,6 +24,8 @@ use crate::article::storage::{
     fetch_index_links,
 };
 
+pub use crate::filters::SharedData;
+
 pub use admin::{
     admin_route,
     login_page_route,
@@ -35,8 +36,6 @@ pub use admin::{
     update_article_route,
     delete_article_route,
 };
-
-pub type SharedData = Arc<Mutex<CommonData>>;
 
 pub type WarpResult = Result<
     warp::reply::Response,


### PR DESCRIPTION
There remains the possibility of further refactoring, perhaps combining the filters and rendering parts (in routes.rs) into submodules.