### PR TITLE
Add new plain dark and light themes

### DIFF
--- a/content/assets/js/captioneer.js
+++ b/content/assets/js/captioneer.js
@@ -28,10 +28,12 @@
 
         const parent = image.parentNode;
         const text = image.getAttribute('alt');
+        const br = D.createElement('br');
 
         image.setAttribute('data-action', 'zoom');
 
         caption.appendChild(D.createTextNode(text));
+        caption.appendChild(br);
 
         figure.appendChild(image);
         figure.appendChild(caption);

--- a/content/assets/js/dimma.js
+++ b/content/assets/js/dimma.js
@@ -18,7 +18,7 @@
             currentFocus.classList.remove("focus");
         }
         currentFocus = evt.target;
-        currentFocus.classList.remove("focus");
+        currentFocus.classList.add("focus");
         B.classList.add("dimmed");
 
         currentFocus.parentNode.scrollIntoView({ behavior: "smooth", block: "center" });

--- a/content/assets/js/exif-popover.js
+++ b/content/assets/js/exif-popover.js
@@ -52,9 +52,23 @@
 
   if (window.EXIF) {
     exifPopover = document.createElement('div');
+    exifPopover.innerHTML = "--<br>--";
     exifPopover.id = 'exif-popover';
     document.body.appendChild(exifPopover);
     document.body.addEventListener('mouseover', showExifOnImage);
     document.body.addEventListener('mouseout', hideExif);
+
+    document.body.addEventListener('click', function (event) {
+      setTimeout(function () {
+        if (this.target.nodeName !== 'IMG') return;
+        if (this.target.classList.contains('focus')) {
+          if (exifPopover.classList.contains('active')) {
+            hideExif();
+          } else {
+            showExifOnImage(this);
+          }
+        }
+      }.bind(event), 0);
+    })
   }
 }());

--- a/content/assets/js/theme-selector.js
+++ b/content/assets/js/theme-selector.js
@@ -10,7 +10,8 @@
         if (parts.length === 2) return parts.pop().split(';').shift();
     }
 
-    const currentTheme = getCookie('theme');
+    // TODO: don't hard-code default selection
+    const currentTheme = getCookie('theme') || 'topo.css';
 
     const TEN_YEARS = 60*60*24*365*2;
 

--- a/content/assets/themes/pastel_night.css
+++ b/content/assets/themes/pastel_night.css
@@ -103,7 +103,7 @@ header h1 {
 header .logout {
     grid-row: 1/3;
     grid-column: 3 / 4;
-    text-align: right;
+    justify-self: end;
 }
 header h2 {
     grid-row: 2/3;
@@ -141,9 +141,13 @@ footer {
     padding: 1em;
 }
 
-article {
-    max-width: 35rem;
-    margin: 0 auto;
+article > section {
+    display: grid;
+    grid-template-columns: 1fr 35rem 1fr;
+}
+
+article > section > * {
+    grid-column: 2/3;
 }
 
 #home-page-info {
@@ -210,6 +214,12 @@ ul.article-list > li {
 
 ul.article-list > li:last-child {
     border-bottom-width: 0;
+}
+
+.article p,
+.article ul {
+    overflow-x: auto;
+    overflow-y: hidden;
 }
 
 nav {
@@ -298,11 +308,7 @@ hr {
 }
 
 p.img {
-    position: relative;
-    left: 50%;
-    width: 98vw;
-    max-width: 100vw;
-    margin-left: -49vw;
+    grid-column: 1/4;
     margin-bottom: 2em;
     padding-top: 1vh;
 }
@@ -363,10 +369,10 @@ body.dimmed img.focus + figcaption, body.dimmed img.focus + em {
 #comments {
     box-sizing: border-box;
     background-color: var(--lighter-bg);
-    margin: 1em -3em 2em;
+    margin: 1em 0 2em;
     padding: 1em 3em;
     border-color: var(--light-bg);
-    border-width: 1px;
+    border-width: 1px 0;
     border-style: solid;
 }
 
@@ -419,6 +425,7 @@ body.dimmed img.focus + figcaption, body.dimmed img.focus + em {
 #comment-form textarea:focus {
     border-radius: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8);
+    color: var(--accent-color2-lighter);
 }
 
 #comment-form textarea {
@@ -477,6 +484,9 @@ body.dimmed img.focus + figcaption, body.dimmed img.focus + em {
     header h2 {
         grid-row: 3/4;
         grid-column: 1/4;
+    }
+    article > section {
+        grid-template-columns: 0.5em auto 0.5em;
     }
     section.content,
     section.post-content {

--- a/content/assets/themes/plain_dark.css
+++ b/content/assets/themes/plain_dark.css
@@ -1,0 +1,347 @@
+/* Plain Dark */
+:root {
+    --main-bg: #333;
+    --darker-bg: #000;
+    --input-bg: #000;
+    --plain-text: #ccc;
+    --darker-text: #aaa;
+    --link-normal: #618bb3;
+    --link-visited: #8d7097;
+    --link-header: #0084d1;
+}
+
+html {
+    margin: 0;
+    padding: 0;
+    background-color: var(--main-bg);
+    color: var(--plain-text);
+    font-family: "IBM Plex Serif", serif;
+    font-size: 18px;
+}
+
+body {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0 0.5rem;
+}
+
+header,
+footer {
+    background-color: var(--darker-bg);
+    color: var(--darker-text);
+    padding: 0.5em 0.5rem;
+    margin: 0 -0.5rem 1em;
+    box-shadow:
+        -1.5rem 0 0 0 var(--darker-bg),
+         1.5rem 0 0 0 var(--darker-bg);
+
+}
+
+header {
+    display: grid;
+    grid-template-columns: 1fr 35em 1fr;
+    grid-template-rows: 2em 1fr;
+}
+
+.index header {
+    grid-template-rows: 1fr;
+}
+
+.tag-index header {
+    grid-template-rows: auto auto auto;
+}
+
+article > section {
+    display: grid;
+    grid-template-columns: 1fr 35rem 1fr;
+}
+
+article > section > * {
+    grid-column: 2/3;
+}
+
+footer {
+    margin-bottom: 0;
+}
+
+.link-box {
+    grid-row: 1/2;
+}
+
+.home.link-box {
+    grid-column: 1/2;
+}
+
+.logout.link-box {
+    grid-column: 3/4;
+    justify-self: end;
+}
+
+.index .logout.link-box {
+    align-self: center;
+}
+
+.tag-index .logout.link-box,
+.article .logout.link-box {
+    grid-column: 2/4;
+}
+
+#home-page-info {
+    margin: 1em 0;
+}
+
+h1 {
+    margin: 0.2em 0 0.5em;
+    grid-row: 2/3;
+    grid-column: 2/3;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+}
+
+.index h1 {
+    grid-row: 1/2;
+}
+
+h2 {
+    margin: 0 0 0.1em;
+}
+
+.tag-index header h2 {
+    grid-row: 3/4;
+    grid-column: 2/4;
+}
+
+h3 {
+    margin: 0 0 0.3em;
+}
+
+p {
+    margin: 0 0 1em;
+}
+
+a {
+    color: var(--link-normal);
+}
+
+a:visited {
+    color: var(--link-visited);
+}
+
+header a,
+footer a {
+    color: var(--link-header);
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+}
+
+header a:visited,
+footer a:visited {
+    color: var(--link-header);
+}
+
+ul.article-list,
+ul.tags {
+    list-style: none;
+    margin: 0 0 1em;
+    padding: 0;
+}
+
+li {
+    margin: 0;
+    padding: 0;
+}
+
+ul.article-list > li {
+    margin-bottom: 1em;
+}
+
+ul.tags {
+    font-size: 80%;
+}
+
+ul.tags::before {
+    content: "Tags: ";
+}
+
+ul.tags li {
+    display: inline-block;
+}
+ul.tags li a::after {
+    content: ", ";
+}
+ul.tags li:last-child a::after {
+    content: "";
+}
+
+pre {
+    overflow-x: auto;
+    margin: 0 0 1em;
+    padding: 0.5em;
+    background-color: var(--darker-bg);
+}
+
+code {
+    font-size: 14px;
+}
+
+p > code {
+    background-color: var(--darker-bg);
+    padding: 0 0.3em;
+}
+
+p.img {
+    grid-column: 1/4;
+    margin-bottom: 2em;
+    padding-top: 1vh;
+}
+
+p.img figure {
+    margin: 0;
+}
+
+p.img img {
+    padding: 0;
+    box-shadow: 0 1px 4px rgb(0 0 0 / 20%);
+    cursor: pointer;
+    border-radius: 2px;
+}
+
+#article-body img {
+    display: block;
+    max-width: 100%;
+    max-height: 95vh;
+    height: auto;
+    margin: 0 auto;
+}
+
+#article-body figcaption, #article-body img + em {
+    text-align: center;
+    font-size: 0.9em;
+    display: block;
+    padding: 0.3em 0;
+    line-height: 1.3;
+    font-style: italic;
+}
+
+body.dimmed img.focus + figcaption, body.dimmed img.focus + em {
+    color: #ddd;
+}
+
+#exif-popover {
+    position: absolute;
+    display: none;
+    background-color: rgba(0, 0, 0, 0.5);
+    color: #eee;
+    padding: 0.5em;
+    font-size: 0.8em;
+    border-radius: 0.5em;
+    text-shadow: 0 1px 0 #000;
+}
+
+#exif-popover.active {
+    display: block;
+}
+
+.article p,
+.article ul {
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+nav {
+    display: grid;
+    grid-template-columns: 1fr 8em 1fr;
+    grid-template-rows: 1fr;
+    margin-bottom: 1em;
+}
+
+.article nav {
+    border-top: 1px dotted var(--plain-text);
+    padding-top: 1em;
+    grid-template-columns: 1fr 1em 1fr;
+    grid-template-rows: 2em 1fr 2em;
+}
+
+nav .more-articles-text {
+    text-align: center;
+    grid-row: 1/2;
+    grid-column: 1/4;
+}
+
+nav .nav-prev {
+    justify-self: end;
+    text-align: right;
+}
+nav .nav-sep {
+    justify-self: center;
+    text-align: center;
+}
+nav .nav-next {
+    justify-self: start;
+}
+nav .footer-home-link-box {
+    grid-row: 3/4;
+    grid-column: 1/4;
+    margin: 0;
+    justify-self: center;
+    align-self: end;
+}
+
+#comments {
+    margin-bottom: 1em;
+}
+
+#comments ul {
+    padding: 0;
+}
+
+.comment-age {
+    font-size: 80%;
+}
+.comment-age::before {
+    content: "→ ";
+}
+
+#comments label,
+#comments input,
+#comments textarea {
+    display: block;
+}
+
+#comments input,
+#comments textarea {
+    -webkit-appearance: none;
+    appearance: none;
+    font: inherit;
+    box-sizing: border-box;
+    margin: 0 0 0.5em;
+    padding: 0.2em 0.5em;
+    border: 1px solid var(--plain-text);
+    background-color: var(--input-bg);
+    color: var(--plain-text);
+    border-radius: 2px;
+}
+
+#comments input {
+    width: 50%;
+}
+
+#comments textarea {
+    width: 100%;
+    height: 10em;
+}
+
+@media (max-width: 47rem) {
+    header {
+        grid-template-columns: 1fr auto 1fr;
+    }
+    header h1 {
+        padding-left: 0.5rem;
+        grid-column: 1/4;
+    }
+    .tag-index header h2 {
+        grid-column: 1/4;
+        padding-left: 0.5rem;
+    }
+    article > section {
+        grid-template-columns: 0.5em auto 0.5em;
+    }
+}

--- a/content/assets/themes/plain_darkroom.css
+++ b/content/assets/themes/plain_darkroom.css
@@ -1,0 +1,375 @@
+/* Darkroom */
+:root {
+    --main-bg: #000;
+    --darker-bg: #200;
+    --input-bg: #000;
+    --plain-text: #b00;
+    --header-text: #d55;
+    --link-normal: #414c72;
+    --link-visited: #7b418f;
+    --link-header: #414c72;
+    --link-index-visited: #5c3868; /* slightly darker than normal links */
+    --code: #844;
+}
+
+html {
+    margin: 0;
+    padding: 0;
+    background-color: var(--main-bg);
+    color: var(--plain-text);
+    font-family: "IBM Plex Serif", serif;
+    font-size: 18px;
+}
+
+body {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0 0.5rem;
+}
+
+header,
+footer {
+    background-color: var(--darker-bg);
+    color: var(--header-text);
+    padding: 0.5em 0.5rem;
+    margin: 0 -0.5rem 1em;
+    box-shadow:
+        -1.5rem 0 0 0 var(--darker-bg),
+         1.5rem 0 0 0 var(--darker-bg);
+
+}
+
+header {
+    display: grid;
+    grid-template-columns: 1fr 35em 1fr;
+    grid-template-rows: 2em 1fr;
+    border-bottom: 1px solid var(--header-text);
+}
+
+.index header {
+    grid-template-rows: 1fr;
+}
+
+.tag-index header {
+    grid-template-rows: auto auto auto;
+}
+
+article > section {
+    display: grid;
+    grid-template-columns: 1fr 35rem 1fr;
+}
+
+article > section > * {
+    grid-column: 2/3;
+}
+
+footer {
+    margin-bottom: 0;
+}
+
+.link-box {
+    grid-row: 1/2;
+}
+
+.home.link-box {
+    grid-column: 1/2;
+}
+
+.logout.link-box {
+    grid-column: 3/4;
+    justify-self: end;
+}
+
+.index .logout.link-box {
+    align-self: center;
+}
+
+.tag-index .logout.link-box,
+.article .logout.link-box {
+    grid-column: 2/4;
+}
+
+#home-page-info {
+    margin: 1em 0;
+}
+
+h1, h2, h3, h4 {
+    font-family: "IBM Plex Sans", sans-serif;
+}
+
+h1, h2, h3 {
+    font-weight: 300;
+}
+
+h1 {
+    margin: 0.2em 0 0.5em;
+    grid-row: 2/3;
+    grid-column: 2/3;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+}
+
+.index h1 {
+    grid-row: 1/2;
+}
+
+h2 {
+    margin: 0 0 0.1em;
+}
+
+.tag-index header h2 {
+    grid-row: 3/4;
+    grid-column: 2/4;
+}
+
+h3 {
+    margin: 0 0 0.3em;
+    color: var(--header-text);
+}
+
+p {
+    margin: 0 0 1em;
+}
+
+a {
+    color: var(--link-normal);
+}
+
+a:visited {
+    color: var(--link-visited);
+}
+
+.article-list h2 a:visited {
+    color: var(--link-index-visited);
+}
+
+header a,
+footer a {
+    color: var(--link-header);
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+}
+
+header a:visited,
+footer a:visited {
+    color: var(--link-header);
+}
+
+ul.article-list,
+ul.tags {
+    list-style: none;
+    margin: 0 0 1em;
+    padding: 0;
+}
+
+li {
+    margin: 0;
+    padding: 0;
+}
+
+ul.article-list > li {
+    margin-bottom: 1em;
+}
+
+ul.tags {
+    font-size: 80%;
+}
+
+ul.tags::before {
+    content: "Tags: ";
+}
+
+ul.tags li {
+    display: inline-block;
+}
+ul.tags li a::after {
+    content: ", ";
+}
+ul.tags li:last-child a::after {
+    content: "";
+}
+
+pre {
+    overflow-x: auto;
+    margin: 0 0 1em;
+    padding: 0.5em;
+    background-color: var(--darker-bg);
+}
+
+code {
+    font-size: 14px;
+    color: var(--code);
+}
+
+p > code {
+    background-color: var(--darker-bg);
+    padding: 0 0.3em;
+}
+
+p.img {
+    grid-column: 1/4;
+    margin-bottom: 2em;
+    padding-top: 1vh;
+}
+
+p.img figure {
+    margin: 0;
+}
+
+p.img img {
+    padding: 0;
+    box-shadow: 0 1px 4px rgb(0 0 0 / 20%);
+    cursor: pointer;
+    border-radius: 2px;
+    filter: brightness(50%);
+}
+
+#article-body img {
+    display: block;
+    max-width: 100%;
+    max-height: 95vh;
+    height: auto;
+    margin: 0 auto;
+}
+
+#article-body figcaption, #article-body img + em {
+    text-align: center;
+    font-size: 0.9em;
+    display: block;
+    padding: 0.3em 0;
+    line-height: 1.3;
+    font-style: italic;
+}
+
+p.img figcaption::after {
+    content: "(click or tap image to show it at full brightness)";
+    font-style: normal;
+}
+
+body.dimmed p.img img.focus {
+    filter: none;
+}
+
+body.dimmed img.focus + figcaption, body.dimmed img.focus + em {
+    color: var(--header-text);
+}
+
+#exif-popover {
+    position: absolute;
+    display: none;
+    background-color: rgba(0, 0, 0, 0.5);
+    color: var(--header-text);
+    padding: 0.5em;
+    font-size: 0.8em;
+    border-radius: 0.5em;
+    text-shadow: 0 1px 0 #000;
+}
+
+#exif-popover.active {
+    display: block;
+}
+
+.article p,
+.article ul {
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+nav {
+    display: grid;
+    grid-template-columns: 1fr 8em 1fr;
+    grid-template-rows: 1fr;
+    margin-bottom: 1em;
+}
+
+.article nav {
+    border-top: 1px dotted var(--plain-text);
+    padding-top: 1em;
+    grid-template-columns: 1fr 1em 1fr;
+    grid-template-rows: 2em 1fr 2em;
+}
+
+nav .more-articles-text {
+    text-align: center;
+    grid-row: 1/2;
+    grid-column: 1/4;
+}
+
+nav .nav-prev {
+    justify-self: end;
+    text-align: right;
+}
+nav .nav-sep {
+    justify-self: center;
+    text-align: center;
+}
+nav .nav-next {
+    justify-self: start;
+}
+nav .footer-home-link-box {
+    grid-row: 3/4;
+    grid-column: 1/4;
+    margin: 0;
+    justify-self: center;
+    align-self: end;
+}
+
+#comments {
+    margin-bottom: 1em;
+}
+
+#comments ul {
+    padding: 0;
+}
+
+.comment-age {
+    font-size: 80%;
+}
+.comment-age::before {
+    content: "→ ";
+}
+
+#comments label,
+#comments input,
+#comments textarea {
+    display: block;
+}
+
+#theme-selector,
+#comments input,
+#comments textarea {
+    -webkit-appearance: none;
+    appearance: none;
+    font: inherit;
+    box-sizing: border-box;
+    margin: 0 0 0.5em;
+    padding: 0.2em 0.5em;
+    border: 1px solid var(--plain-text);
+    background-color: var(--input-bg);
+    color: var(--plain-text);
+    border-radius: 2px;
+}
+
+#comments input {
+    width: 50%;
+}
+
+#comments textarea {
+    width: 100%;
+    height: 10em;
+}
+
+@media (max-width: 47rem) {
+    header {
+        grid-template-columns: 1fr auto 1fr;
+    }
+    header h1 {
+        padding-left: 0.5rem;
+        grid-column: 1/4;
+    }
+    .tag-index header h2 {
+        grid-column: 1/4;
+        padding-left: 0.5rem;
+    }
+    article > section {
+        grid-template-columns: 0.5em auto 0.5em;
+    }
+}

--- a/content/assets/themes/plain_light.css
+++ b/content/assets/themes/plain_light.css
@@ -1,0 +1,347 @@
+/* Plain Light */
+:root {
+    --main-bg: #eee;
+    --darker-bg: #ddd;
+    --input-bg: #fff;
+    --plain-text: #444;
+    --link-normal: #0064c1;
+    --link-visited: #8b7195;
+    --link-header: #33acf2;
+}
+
+html {
+    margin: 0;
+    padding: 0;
+    background-color: var(--main-bg);
+    color: var(--plain-text);
+    font-family: "IBM Plex Serif", serif;
+    font-size: 18px;
+}
+
+body {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0 0.5rem;
+}
+
+header,
+footer {
+    background-color: var(--plain-text);
+    color: var(--main-bg);
+    padding: 0.5em 0.5rem;
+    margin: 0 -0.5rem 1em;
+    box-shadow:
+        -1.5rem 0 0 0 var(--plain-text),
+         1.5rem 0 0 0 var(--plain-text);
+}
+
+header {
+    display: grid;
+    grid-template-columns: 1fr 35em 1fr;
+    grid-template-rows: 2em 1fr;
+}
+
+.index header {
+    grid-template-rows: 1fr;
+}
+
+.tag-index header {
+    grid-template-rows: auto auto auto;
+}
+
+footer {
+    margin-bottom: 0;
+}
+
+.link-box {
+    grid-row: 1/2;
+}
+
+.home.link-box {
+    grid-column: 1/2;
+}
+
+.logout.link-box {
+    grid-column: 2/4;
+    justify-self: end;
+}
+
+.index .logout.link-box {
+    align-self: center;
+}
+
+.tag-index .logout.link-box,
+.article .logout.link-box {
+    grid-column: 2/4;
+}
+
+#home-page-info {
+    margin: 1em 0;
+}
+
+h1 {
+    background-color: var(--plain-text);
+    color: var(--main-bg);
+    margin: 0.2em 0 0.5em;
+    grid-row: 2/3;
+    grid-column: 2/3;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+}
+
+.index h1 {
+    grid-row: 1/2;
+}
+
+h2 {
+    margin: 0 0 0.1em;
+}
+
+.tag-index header h2 {
+    grid-row: 3/4;
+    grid-column: 2/4;
+}
+
+article > section {
+    display: grid;
+    grid-template-columns: 1fr 35rem 1fr;
+}
+
+article > section > * {
+    grid-column: 2/3;
+}
+
+h3 {
+    margin: 0 0 0.3em;
+}
+
+p {
+    margin: 0 0 1em;
+}
+
+a {
+    color: var(--link-normal);
+}
+
+a:visited {
+    color: var(--link-visited);
+}
+
+header a,
+footer a {
+    color: var(--link-header);
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+}
+
+header a:visited,
+footer a:visited {
+    color: var(--link-header);
+}
+
+ul.article-list,
+ul.tags {
+    list-style: none;
+    margin: 0 0 1em;
+    padding: 0;
+}
+
+li {
+    margin: 0;
+    padding: 0;
+}
+
+ul.article-list > li {
+    margin-bottom: 1em;
+}
+
+ul.tags {
+    font-size: 80%;
+}
+
+ul.tags::before {
+    content: "Tags: ";
+}
+
+ul.tags li {
+    display: inline-block;
+}
+ul.tags li a::after {
+    content: ", ";
+}
+ul.tags li:last-child a::after {
+    content: "";
+}
+
+pre {
+    overflow-x: auto;
+    margin: 0 0 1em;
+    padding: 0.5em;
+    background-color: var(--darker-bg);
+}
+
+code {
+    font-size: 14px;
+}
+
+p > code {
+    background-color: var(--darker-bg);
+    padding: 0 0.3em;
+}
+
+p.img {
+    grid-column: 1/4;
+    margin-bottom: 2em;
+    padding-top: 1vh;
+}
+
+p.img figure {
+    margin: 0;
+}
+
+p.img img {
+    padding: 0;
+    box-shadow: 0 1px 4px rgb(0 0 0 / 20%);
+    cursor: pointer;
+    border-radius: 2px;
+}
+
+#article-body img {
+    display: block;
+    max-width: 100%;
+    max-height: 95vh;
+    height: auto;
+    margin: 0 auto;
+}
+
+#article-body figcaption, #article-body img + em {
+    text-align: center;
+    font-size: 0.9em;
+    display: block;
+    padding: 0.3em 0;
+    line-height: 1.3;
+    font-style: italic;
+}
+
+body.dimmed img.focus + figcaption, body.dimmed img.focus + em {
+    color: #ddd;
+}
+
+#exif-popover {
+    position: absolute;
+    display: none;
+    background-color: rgba(0, 0, 0, 0.5);
+    color: #eee;
+    padding: 0.5em;
+    font-size: 0.8em;
+    border-radius: 0.5em;
+    text-shadow: 0 1px 0 #000;
+}
+
+#exif-popover.active {
+    display: block;
+}
+
+.article p,
+.article ul {
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+nav {
+    display: grid;
+    grid-template-columns: 1fr 8em 1fr;
+    grid-template-rows: 1fr;
+    margin-bottom: 1em;
+}
+
+.article nav {
+    border-top: 1px dotted var(--plain-text);
+    padding-top: 1em;
+    grid-template-columns: 1fr 1em 1fr;
+    grid-template-rows: 2em 1fr 2em;
+}
+
+nav .more-articles-text {
+    text-align: center;
+    grid-row: 1/2;
+    grid-column: 1/4;
+}
+
+nav .nav-prev {
+    justify-self: end;
+    text-align: right;
+}
+nav .nav-sep {
+    justify-self: center;
+    text-align: center;
+}
+nav .nav-next {
+    justify-self: start;
+}
+nav .footer-home-link-box {
+    grid-row: 3/4;
+    grid-column: 1/4;
+    margin: 0;
+    justify-self: center;
+    align-self: end;
+}
+
+#comments {
+    margin-bottom: 1em;
+}
+
+#comments ul {
+    padding: 0;
+}
+
+.comment-age {
+    font-size: 80%;
+}
+.comment-age::before {
+    content: "→ ";
+}
+
+#comments label,
+#comments input,
+#comments textarea {
+    display: block;
+}
+
+#comments input,
+#comments textarea {
+    -webkit-appearance: none;
+    appearance: none;
+    font: inherit;
+    box-sizing: border-box;
+    margin: 0 0 0.5em;
+    padding: 0.2em 0.5em;
+    border: 1px solid var(--plain-text);
+    background-color: var(--input-bg);
+    color: var(--plain-text);
+    border-radius: 2px;
+}
+
+#comments input {
+    width: 50%;
+}
+
+#comments textarea {
+    width: 100%;
+    height: 10em;
+}
+
+@media (max-width: 47rem) {
+    header {
+        grid-template-columns: 1fr 0 2fr;
+    }
+    header h1 {
+        padding-left: 0.5rem;
+        grid-column: 1/4;
+    }
+    .tag-index header h2 {
+        grid-column: 1/4;
+        padding-left: 0.5rem;
+    }
+    article > section {
+        grid-template-columns: 0.5em auto 0.5em;
+    }
+}

--- a/content/assets/themes/topo.css
+++ b/content/assets/themes/topo.css
@@ -296,9 +296,14 @@ header {
     height: 6em;
 }
 
+.index header {
+    grid-template-columns: 8em 1fr;
+}
+
 .article header {
     height: auto;
     grid-template-rows: 2.5em 1fr;
+    grid-template-columns: 8em 1fr;
 }
 
 footer {
@@ -331,7 +336,7 @@ h1, h2, h3, h4, .tags {
 }
 
 h1 {
-    grid-column: 2 / 3;
+    grid-column: 1 / 3;
     grid-row: 2 / 3;
     align-self: center;
     font-size: 2.8em;
@@ -360,8 +365,7 @@ h1 {
 }
 
 #home-page-info {
-    padding: 1em 0.5em 0.3em;
-    border: 1px dotted #ccc;
+    padding: 1em 0 0.3em;
     margin-bottom: 2em;
 }
 
@@ -486,6 +490,9 @@ header a:hover svg {
 
     header h1 {
         grid-column: 1 / 3;
+    }
+    .index header h1 {
+        grid-row: 2/3;
     }
     header .logout.link-box {
         grid-column: 2 / 3;
@@ -704,6 +711,12 @@ body.dimmed img.focus + figcaption, body.dimmed img.focus + em {
 
 #exif-popover.active {
     display: block;
+}
+
+.article p,
+.article ul {
+    overflow-x: auto;
+    overflow-y: hidden;
 }
 
 #comments ul {

--- a/content/templates/_header.html.hbs
+++ b/content/templates/_header.html.hbs
@@ -11,7 +11,7 @@
 
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preload" as="style" href="//fonts.googleapis.com/css?family=IBM+Plex+Serif:400,400i,700|IBM+Plex+Sans:300,300i,400,700&display=swap">
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=IBM+Plex+Serif:400,400i,700|IBM+Plex+Sans:300,300i,400,700&display=swap" media="print" onload="this.media='all'">
+    <link rel="stylesheet"         href="//fonts.googleapis.com/css?family=IBM+Plex+Serif:400,400i,700|IBM+Plex+Sans:300,300i,400,700&display=swap" media="print" onload="this.media='all'">
     {{#if theme}}
       <link rel="stylesheet" href="{{asset_path theme}}" id="main-style-tag">
     {{else}}

--- a/content/templates/article.html.hbs
+++ b/content/templates/article.html.hbs
@@ -29,7 +29,9 @@
     <a href="/article/{{prev.slug}}">&larr; {{prev.title}}</a>
   </div>
   {{else}}
-  <span class="empty"></span>
+  <div class="nav-prev">
+    <span>↻ no more articles</span>
+  </div>
   {{/if}}
   <span class="nav-sep">&middot;</span>
   {{#if next}}
@@ -37,7 +39,9 @@
     <a href="/article/{{next.slug}}">{{next.title}} &rarr;</a>
   </div>
   {{else}}
-  <span class="empty"></span>
+  <div class="nav-next">
+    <span>no more articles ↺</span>
+  </div>
   {{/if}}
   <p class="footer-home-link-box">
   <a href="{{return_path}}" class="index-link">↰ {{{return_text return_path}}}</a>

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,7 @@ impl Config {
                 filename,
             })
         });
+        themes.sort_by(|t1, t2| t1.name.cmp(&t2.name));
         themes
     }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -3,10 +3,10 @@ use std::{
     path::PathBuf,
 };
 use axum::{
-    extract::Extension,
+    extract::{Extension, Path},
     handler::Handler,
     http::StatusCode,
-    response::IntoResponse,
+    response::{IntoResponse, Redirect},
     Router,
     routing::{
         delete,
@@ -71,10 +71,13 @@ pub fn init(shared_data: SharedData) -> Router {
 
     Router::new()
         .route("/",                   get(home_handler))
-        .route("/articles/:page",     get(index_handler))
+        .route("/:legacy_slug",       get(|Path(slug): Path<String>| async move {
+            Redirect::permanent(&(String::from("/article/") + &slug))
+        }))
         .route("/articles",           post(create_article_handler))
-        .route("/article/:slug",      put(update_article_handler))
+        .route("/articles/:page_or_slug",     get(index_handler))
         .route("/article/:slug",      get(article_handler))
+        .route("/article/:slug",      put(update_article_handler))
         .route("/article/:slug",      delete(delete_article_handler))
         .route("/article/:slug/text", get(article_text_handler))
 


### PR DESCRIPTION
Add 'no more articles' text to article nav

Sort themes by name

Add ; separator when concatenating JS files

Redirect old article route to new one if possible
Old route was /articles/:slug but /articles is now used for the index, i.e. /articles/:page, so try to convert the extracted value to a number, and if that fails, assume it's a slug and redirect accordingly.

Add 'Darkroom' theme; fix dimma and captioneer JS

A new theme for reading in super dark conditions.

Update JS manifest last modified automatically
When the manifest is compiled, set its last_modified time to match that of the newest file it includes.

Add redirect for old Ghost article routes