### PR TITLE
Major refactor of article build/store/view

### DIFF
--- a/src/commondata.rs
+++ b/src/commondata.rs
@@ -4,14 +4,13 @@ use handlebars::Handlebars;
 use crate::hb::create_handlebars;
 use crate::article::gather_fs_articles;
 use crate::errors::ParseError;
-use crate::article::view::ContentView;
+use crate::article::builder::ParsedArticle;
 use crate::comments::Comments;
 use crate::config::Config;
 
-#[derive(Clone)]
 pub struct CommonData {
     pub hbs: Handlebars<'static>,
-    pub articles: Vec<ContentView>,
+    pub articles: Vec<ParsedArticle>,
     pub comments: Comments,
     pub config: Config,
     pub session_id: Option<String>,


### PR DESCRIPTION
Renamed ContentView to ParsedArticle and moved it into the builder module. Storage module is now only concerned with fetching and updating articles; builder is responsible for reading from disk and parsing. View module is simplified to just index and article views, and in all cases, everything is borrowed from the master ParsedArticle vec provided by storage, which means a lot fewer clones.